### PR TITLE
Abstract over list of application creation to minimize code duplication

### DIFF
--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -120,15 +120,16 @@ cd "${SCRIPT_PATH}"
 if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
     python3 -m venv "${TEMPDIR}/ve"
     . "${TEMPDIR}/ve/bin/activate"
-    "${TEMPDIR}/ve/bin/pip3" install --upgrade pip
-    "${TEMPDIR}/ve/bin/pip3" install --upgrade cryptograpy
-    
+    "${TEMPDIR}/ve/bin/pip3" install --upgrade \
+      cryptograpy \
+      debugpy \
+      more-itertools \
+      pip
+
     # Pin a version of our python SDK's so that breaking changes don't spuriously break our tests.
     # Please update as necessary.
     "${TEMPDIR}/ve/bin/pip3" install py-algorand-sdk==1.9.0b1
     
-    # Enable remote debugging:
-    "${TEMPDIR}/ve/bin/pip3" install --upgrade debugpy
     duration "e2e client setup"
 
     if [ $INTERACTIVE ]; then


### PR DESCRIPTION
For illustrative purposes, abstract over list of application creation to minimize code duplication.  

Notes:
* As a way to boost my Python learning while reviewing on https://github.com/algorand/go-algorand/pull/3693, I replaced imperative application creation calls with a helper method.   
* The PR's minor novelty is using [more-itertools](https://pypi.org/project/more-itertools/) to abstract over partitioning a list of errors and transaction infos.  
* Since the imperative logic is also relatively straightforward, I don't expect to have the PR merged.  I'm posting it in case there's other folks new to Python that can benefit from seeing the before/after transformation.  Though if we wish to merge it, I'm open to feedback.